### PR TITLE
Add struct trait Asset into stdlib

### DIFF
--- a/stdlib/Asset.flint
+++ b/stdlib/Asset.flint
@@ -1,0 +1,24 @@
+// Any currency should implement this trait to be able to use it fully.
+// TODO: semantic check preventing cross-asset transfers
+struct trait Asset {
+  // Initialises the asset "unsafely", i.e. from `amount` given as an integer.
+  public init(unsafeRawValue: Int)
+  
+  // Initialises the asset by transferring `amount` from an existing asset.
+  // Should check if `source` has sufficient funds, and cause a fatal error
+  // if not.
+  public init(source: inout Asset, amount: Int)
+  
+  // Initialises the asset by transferring all funds from `source`.
+  // `source` should be left empty.
+  public init(source: inout Asset)
+  
+  // Moves `amount` from `source` into `this` asset.
+  mutating public func transfer(source: inout Asset, amount: Int)
+  
+  // Moves all funds from `source` into `this` asset.
+  mutating public func transfer(source: inout Asset)
+  
+  // Returns the funds contained in this asset, as an integer.
+  public func getRawValue() -> Int
+}

--- a/stdlib/Asset.flint
+++ b/stdlib/Asset.flint
@@ -2,24 +2,42 @@
 // TODO: semantic check preventing cross-asset transfers
 struct trait Asset {
   // Initialises the asset "unsafely", i.e. from `amount` given as an integer.
-  public init(unsafeRawValue: Int) {
-    setRawValue(unsafeRawValue)
-  }
+  public init(unsafeRawValue: Int)
   
   // Initialises the asset by transferring `amount` from an existing asset.
   // Should check if `source` has sufficient funds, and cause a fatal error
   // if not.
-  public init(source: inout Asset, amount: Int)
+  public init(source: inout Asset, amount: Int) {
+    if source.getRawValue() < amount {
+      fatalError()
+    }
+    
+    source.setRawValue(source.getRawValue() - amount)
+    setRawValue(getRawValue() + amount)
+  }
   
   // Initialises the asset by transferring all funds from `source`.
   // `source` should be left empty.
-  public init(source: inout Asset)
+  public init(source: inout Asset) {
+    let value: Int = source.getRawValue()
+    source.setRawValue(0)
+    setRawValue(value)
+  }
   
   // Moves `amount` from `source` into `this` asset.
-  mutating public func transfer(source: inout Asset, amount: Int)
+  mutating public func transfer(source: inout Asset, amount: Int) {
+    if source.getRawValue() < amount {
+      fatalError()
+    }
+    
+    source.setRawValue(source.getRawValue() - amount)
+    setRawValue(getRawValue() + amount)
+  }
   
   // Moves all funds from `source` into `this` asset.
-  mutating public func transfer(source: inout Asset)
+  mutating public func transfer(source: inout Asset) {
+    transfer(&source, source.getRawValue())
+  }
   
   // Returns the funds contained in this asset, as an integer.
   mutating public func setRawValue(value: Int) -> Int

--- a/stdlib/Asset.flint
+++ b/stdlib/Asset.flint
@@ -2,7 +2,9 @@
 // TODO: semantic check preventing cross-asset transfers
 struct trait Asset {
   // Initialises the asset "unsafely", i.e. from `amount` given as an integer.
-  public init(unsafeRawValue: Int)
+  public init(unsafeRawValue: Int) {
+    setRawValue(unsafeRawValue)
+  }
   
   // Initialises the asset by transferring `amount` from an existing asset.
   // Should check if `source` has sufficient funds, and cause a fatal error
@@ -18,6 +20,9 @@ struct trait Asset {
   
   // Moves all funds from `source` into `this` asset.
   mutating public func transfer(source: inout Asset)
+  
+  // Returns the funds contained in this asset, as an integer.
+  mutating public func setRawValue(value: Int) -> Int
   
   // Returns the funds contained in this asset, as an integer.
   public func getRawValue() -> Int

--- a/stdlib/Asset.flint
+++ b/stdlib/Asset.flint
@@ -18,6 +18,7 @@ struct trait Asset {
   
   // TODO: These implementations cause the compiler to crash due to calling
   // a mutating function from the constructor.
+  // See: https://github.com/flintrocks/flint/issues/30
   //init(unsafeRawValue: Int) {
   //  setRawValue(unsafeRawValue)
   //}

--- a/stdlib/Asset.flint
+++ b/stdlib/Asset.flint
@@ -1,31 +1,44 @@
-// Any currency should implement this trait to be able to use it fully.
+// Any currency should implement this trait to be able to use the currency
+// fully. The default implementations should be left intact, only
+// `getRawValue` and `setRawValue` need to be implemented.
+
 // TODO: semantic check preventing cross-asset transfers
 struct trait Asset {
   // Initialises the asset "unsafely", i.e. from `amount` given as an integer.
-  public init(unsafeRawValue: Int)
+  init(unsafeRawValue: Int)
   
   // Initialises the asset by transferring `amount` from an existing asset.
   // Should check if `source` has sufficient funds, and cause a fatal error
   // if not.
-  public init(source: inout Asset, amount: Int) {
-    if source.getRawValue() < amount {
-      fatalError()
-    }
-    
-    source.setRawValue(source.getRawValue() - amount)
-    setRawValue(getRawValue() + amount)
-  }
+  init(source: inout Asset, amount: Int)
   
   // Initialises the asset by transferring all funds from `source`.
   // `source` should be left empty.
-  public init(source: inout Asset) {
-    let value: Int = source.getRawValue()
-    source.setRawValue(0)
-    setRawValue(value)
-  }
+  init(source: inout Asset)
+  
+  // TODO: These implementations cause the compiler to crash due to calling
+  // a mutating function from the constructor.
+  //init(unsafeRawValue: Int) {
+  //  setRawValue(unsafeRawValue)
+  //}
+  //
+  //init(source: inout Asset, amount: Int) {
+  //  if source.getRawValue() < amount {
+  //    fatalError()
+  //  }
+  //  
+  //  source.setRawValue(source.getRawValue() - amount)
+  //  setRawValue(getRawValue() + amount)
+  //}
+  //
+  //init(source: inout Asset) {
+  //  let value: Int = source.getRawValue()
+  //  source.setRawValue(0)
+  //  setRawValue(0)
+  //}
   
   // Moves `amount` from `source` into `this` asset.
-  mutating public func transfer(source: inout Asset, amount: Int) {
+  mutating func transfer(source: inout Asset, amount: Int) {
     if source.getRawValue() < amount {
       fatalError()
     }
@@ -35,13 +48,13 @@ struct trait Asset {
   }
   
   // Moves all funds from `source` into `this` asset.
-  mutating public func transfer(source: inout Asset) {
+  mutating func transfer(source: inout Asset) {
     transfer(&source, source.getRawValue())
   }
   
   // Returns the funds contained in this asset, as an integer.
-  mutating public func setRawValue(value: Int) -> Int
+  mutating func setRawValue(value: Int) -> Int
   
   // Returns the funds contained in this asset, as an integer.
-  public func getRawValue() -> Int
+  func getRawValue() -> Int
 }

--- a/stdlib/Wei.flint
+++ b/stdlib/Wei.flint
@@ -33,6 +33,11 @@ struct Wei {
     transfer(&source, source.getRawValue())
   }
 
+  mutating func setRawValue(value: Int) -> Int {
+    rawValue = value
+    return rawValue
+  }
+
   func getRawValue() -> Int {
     return rawValue
   }


### PR DESCRIPTION
Closes #16.

# Implementation Overview

This is only the first step in implementing Asset traits fully. In particular, the declaration of `struct trait Asset` was added into `stdlib/Asset.flint`.

The other change is adding `setRawValue` to `stdlib/Wei.flint`. For now this function is not used by any code, but it will be one less step needed for transitioning `Wei` to `Wei: Asset`.

# Takeaways / Next steps

 - Polymorphic `Self` type will need to be implemented before currencies can properly use the trait. (See https://github.com/flintrocks/flint/issues/22 and https://github.com/flintrocks/flint/issues/6)
 - Ideally, each implementing currency only explicitly specifies `setRawValue` and `getRawValue` (even though these will always have the same code). This cannot work at the moment, however, because the defaulted `init` from `Asset` needs to be able to call `setRawValue` (since traits cannot have variables). Mutating functions called from `init` cause the compiler to crash. (See https://github.com/flintrocks/flint/issues/30)
