### PR TITLE
Remove stdlibType from types

### DIFF
--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -359,8 +359,6 @@ public class ASTDumper {
       writeNode("BasicType") {
         self.dump(rawType)
       }
-    case .stdlibType(let type):
-      writeLine("Stdlib type \(type.rawValue)")
     case .userDefinedType(let userDefinedType):
       writeLine("user-defined type \(userDefinedType)")
     case .inoutType(let rawType):

--- a/Sources/AST/Environment/Environment+Memory.swift
+++ b/Sources/AST/Environment/Environment+Memory.swift
@@ -21,10 +21,6 @@ extension Environment {
     case .errorType: return 0
     case .functionType: return 0
 
-    case .stdlibType(let type):
-      return types[type.rawValue]!.properties.reduce(0) { acc, element in
-        return acc + size(of: element.value.rawType)
-      }
     case .userDefinedType(let identifier):
       if isEnumDeclared(identifier),
         case .enumCase(let enumCase) = types[identifier]!.properties.first!.value.property {

--- a/Sources/AST/Environment/Environment+Type.swift
+++ b/Sources/AST/Environment/Environment+Type.swift
@@ -40,11 +40,7 @@ extension Environment {
       }
       return functionInformation.resultType
     case .matchedInitializer:
-      let name = functionCall.identifier.name
-      if let stdlibType = RawType.StdlibType(rawValue: name) {
-        return .stdlibType(stdlibType)
-      }
-      return .userDefinedType(name)
+      return .userDefinedType(functionCall.identifier.name)
     default:
       let eventMatch = matchEventCall(functionCall, enclosingType: enclosingType, scopeContext: scopeContext)
       switch eventMatch {

--- a/Sources/AST/TopLevelModule.swift
+++ b/Sources/AST/TopLevelModule.swift
@@ -181,7 +181,7 @@ public struct TopLevelModule: ASTNode {
                                               closeSquareBracketToken: Token(kind: .punctuation(.closeSquareBracket),
                                                                              sourceLocation: sourceLocation))
       return ([keyParameter], .subscriptExpression(subExpression), Type(inferredType: value, identifier: identifier))
-    case .stdlibType, .rangeType, .userDefinedType, .inoutType, .functionType, .selfType, .any, .errorType:
+    case .rangeType, .userDefinedType, .inoutType, .functionType, .selfType, .any, .errorType:
       return nil
     }
   }

--- a/Sources/IRGen/Property/IRPropertyOffset.swift
+++ b/Sources/IRGen/Property/IRPropertyOffset.swift
@@ -24,7 +24,6 @@ struct IRPropertyOffset {
     let structIdentifier: String
 
     switch enclosingType {
-    case .stdlibType(let type): structIdentifier = type.rawValue
     case .userDefinedType(let type): structIdentifier = type
     default: fatalError()
     }

--- a/Sources/IRGen/Runtime/IRCallerProtectionChecks.swift
+++ b/Sources/IRGen/Runtime/IRCallerProtectionChecks.swift
@@ -62,7 +62,7 @@ struct IRCallerProtectionChecks {
       case .basicType(.address):
         let check = IRRuntimeFunction.isValidCallerProtection(address: "sload(\(offset!)))")
         return "\(variableName) := add(\(variableName), \(check)"
-      case .basicType, .stdlibType, .rangeType, .dictionaryType, .userDefinedType,
+      case .basicType, .rangeType, .dictionaryType, .userDefinedType,
            .inoutType, .functionType, .any, .errorType:
         return ""
       case .selfType:

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
@@ -144,7 +144,9 @@ extension SemanticAnalyzer {
   public func process(parameter: Parameter, passContext: ASTPassContext) -> ASTPassResult<Parameter> {
     var diagnostics = [Diagnostic]()
 
-    if parameter.type.rawType.isUserDefinedType, !parameter.isInout, !parameter.type.isCurrencyType {
+    if parameter.type.rawType.isUserDefinedType,
+      !parameter.isInout,
+      !(parameter.type.isCurrencyType && parameter.isImplicit) {
       // Ensure all structs are passed by reference, for now.
       diagnostics.append(Diagnostic(severity: .error, sourceLocation: parameter.sourceLocation,
                                     message: "Structs cannot be passed by value yet, and have to be passed inout"))

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
@@ -144,7 +144,7 @@ extension SemanticAnalyzer {
   public func process(parameter: Parameter, passContext: ASTPassContext) -> ASTPassResult<Parameter> {
     var diagnostics = [Diagnostic]()
 
-    if parameter.type.rawType.isUserDefinedType, !parameter.isInout {
+    if parameter.type.rawType.isUserDefinedType, !parameter.isInout, !parameter.type.isCurrencyType {
       // Ensure all structs are passed by reference, for now.
       diagnostics.append(Diagnostic(severity: .error, sourceLocation: parameter.sourceLocation,
                                     message: "Structs cannot be passed by value yet, and have to be passed inout"))

--- a/Tests/ParserTests/payable.flint
+++ b/Tests/ParserTests/payable.flint
@@ -6,7 +6,7 @@ Payable :: (any) {
 // CHECK-AST: SpecialDeclaration
 // CHECK-AST:   public
   public init() {}
-  
+
 // CHECK-AST: FunctionDeclaration
 // CHECK-AST: attribute payable
 // CHECK-AST: token: public
@@ -15,7 +15,7 @@ Payable :: (any) {
 // CHECK-AST: Parameter
 // CHECK-AST:   implicit
 // CHECK-AST:   identifier "value"
-// CHECK-AST:   Stdlib type Wei
+// CHECK-AST:   user-defined type Wei
   @payable
   public func foo(implicit value: Wei) {
 

--- a/Tests/SemanticTests/fallback.flint
+++ b/Tests/SemanticTests/fallback.flint
@@ -13,7 +13,7 @@ Test :: caller <- (any) {
   public fallback() {} // expected-error {{A public fallback has already been defined}}
 
   fallback() {}
-  fallback(a: Address, b: Wei) {} //expected-error {{Contract fallback shouldn't have any arguments}}
+  fallback(a: Address, b: inout Wei) {} //expected-error {{Contract fallback shouldn't have any arguments}}
 }
 
 Test :: (a) {


### PR DESCRIPTION
Closes #55 

We currently define an stdlibType in Type.swift, which is used to distinguish stdlib types from other types, specifically currencies.
We should remove this as the standard library should be treated like any other code written in the language.