### PR TITLE
Update swift-lsp dependency to our own forked version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -84,11 +84,11 @@
       },
       {
         "package": "LanguageServerProtocol",
-        "repositoryURL": "https://github.com/theguild/swift-lsp.git",
+        "repositoryURL": "https://github.com/flintrocks/swift-lsp.git",
         "state": {
-          "branch": null,
+          "branch": "master",
           "revision": "ade02a130a19b2f13a59dd531c9bd583d67c01a3",
-          "version": "4.0.1"
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     .package(url: "https://github.com/llvm-swift/FileCheck.git", from: "0.0.4"),
     .package(url: "https://github.com/llvm-swift/Symbolic.git", from: "0.0.1"),
     .package(url: "https://github.com/theguild/json-swift.git", from: "4.0.0"),
-    .package(url: "https://github.com/theguild/swift-lsp.git", from: "4.0.0"),
+    .package(url: "https://github.com/flintrocks/swift-lsp.git", .branch("master")),
     .package(url: "https://github.com/flintrocks/Cuckoo.git", .branch("master")),
   ],
   targets: [


### PR DESCRIPTION
The original version of swift-lsp doesn't support processing input messages asynchronously.