### PR TITLE
Check valid external call exception handling

### DIFF
--- a/Sources/AST/ASTPass/ASTPassContext.swift
+++ b/Sources/AST/ASTPass/ASTPassContext.swift
@@ -156,10 +156,10 @@ extension ASTPassContext {
     set { self[ExternalCallContext.self] = newValue }
   }
 
-  /// When inside a do-block, this property is set to `true`.
-  public var doBlockNestingCount: Int {
-    get { return self[DoBlockNestingCount.self] ?? 0 }
-    set { self[DoBlockNestingCount.self] = newValue }
+  /// Stack of do-catch statements
+  public var doCatchStatementStack: [DoCatchStatement] {
+    get { return self[DoCatchStatementStack.self] ?? [DoCatchStatement]() }
+    set { self[DoCatchStatementStack.self] = newValue }
   }
 
   /// When visiting argument labels in a function call, this property is set to `true`.
@@ -300,8 +300,8 @@ private struct IsExternalFunctionCallContextEntry: PassContextEntry {
   typealias Value = Bool
 }
 
-private struct DoBlockNestingCount: PassContextEntry {
-  typealias Value = Int
+private struct DoCatchStatementStack: PassContextEntry {
+  typealias Value = [DoCatchStatement]
 }
 
 private struct IsAssignment: PassContextEntry {

--- a/Sources/AST/ASTPass/ASTPassContext.swift
+++ b/Sources/AST/ASTPass/ASTPassContext.swift
@@ -180,6 +180,12 @@ extension ASTPassContext {
     set { self[IsFunctionCallArgumentLabel.self] = newValue }
   }
 
+  /// When visiting arguments in a function call, this property is set to `true`.
+  public var isFunctionCallArgument: Bool {
+    get { return self[IsFunctionCallArgument.self] ?? false }
+    set { self[IsFunctionCallArgument.self] = newValue }
+  }
+
   /// When visiting an external configuration parameter, this property is set to `true`.
   /// External configuration params are hyper-parameters to the call, like the gas, the
   /// wei used for the external call or reentrancy.
@@ -333,6 +339,10 @@ private struct IsPropertyDefaultAssignment: PassContextEntry {
 }
 
 private struct IsFunctionCallArgumentLabel: PassContextEntry {
+  typealias Value = Bool
+}
+
+private struct IsFunctionCallArgument: PassContextEntry {
   typealias Value = Bool
 }
 

--- a/Sources/AST/ASTPass/ASTPassContext.swift
+++ b/Sources/AST/ASTPass/ASTPassContext.swift
@@ -162,6 +162,18 @@ extension ASTPassContext {
     set { self[DoCatchStatementStack.self] = newValue }
   }
 
+  /// When inside the condition of an if statement, this property is set to `true`
+  public var isInsideIfCondition: Bool {
+    get { return self[IsInsideIfCondition.self] ?? false }
+    set { self[IsInsideIfCondition.self] = newValue }
+  }
+
+  /// When inside an 'if let ...' construct, this property is set to `true`
+  public var isIfLetConstruct: Bool {
+    get { return self[IsIfLetConstruct.self] ?? false }
+    set { self[IsIfLetConstruct.self] = newValue }
+  }
+
   /// When visiting argument labels in a function call, this property is set to `true`.
   public var isFunctionCallArgumentLabel: Bool {
     get { return self[IsFunctionCallArgumentLabel.self] ?? false }
@@ -302,6 +314,14 @@ private struct IsExternalFunctionCallContextEntry: PassContextEntry {
 
 private struct DoCatchStatementStack: PassContextEntry {
   typealias Value = [DoCatchStatement]
+}
+
+private struct IsInsideIfCondition: PassContextEntry {
+  typealias Value = Bool
+}
+
+private struct IsIfLetConstruct: PassContextEntry {
+  typealias Value = Bool
 }
 
 private struct IsAssignment: PassContextEntry {

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -527,6 +527,9 @@ public struct ASTVisitor {
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
 
+    processResult.element.containsExternalCall =
+      processResult.passContext.doCatchStatementStack.last!.containsExternalCall
+
     processResult.passContext = processResult.passContext.withUpdates {
       _ = $0.doCatchStatementStack.popLast()
     }

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -595,7 +595,6 @@ public struct ASTVisitor {
       // Create an empty scope context.
       processResult.passContext.scopeContext = ScopeContext()
       processResult.passContext.isPropertyDefaultAssignment = true
-      // Check if this is an 'if let' construct
       processResult.element.assignedExpression = processResult.combining(visit(assignedExpression,
                                                                                passContext: processResult.passContext))
       processResult.passContext.isPropertyDefaultAssignment = false

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -518,12 +518,18 @@ public struct ASTVisitor {
     var passContext = passContext
     var processResult = pass.process(doCatchStatement: doCatchStatement, passContext: passContext)
 
-    processResult.passContext.doBlockNestingCount += 1
+    processResult.passContext = processResult.passContext.withUpdates {
+      $0.doCatchStatementStack.append(doCatchStatement)
+    }
+
     let scopeContext = passContext.scopeContext
     processResult.element.doBody = processResult.element.doBody.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
-    processResult.passContext.doBlockNestingCount -= 1
+
+    processResult.passContext = processResult.passContext.withUpdates {
+      _ = $0.doCatchStatementStack.popLast()
+    }
 
     processResult.passContext.scopeContext = scopeContext
     processResult.element.catchBody = processResult.element.catchBody.map { statement in

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -1087,8 +1087,10 @@ public struct ASTVisitor {
     }
     processResult.passContext.isFunctionCallArgumentLabel = false
 
+    processResult.passContext.isFunctionCallArgument = true
     processResult.element.expression = processResult.combining(visit(processResult.element.expression,
                                                                      passContext: processResult.passContext))
+    processResult.passContext.isFunctionCallArgument = false
 
     let postProcessResult = pass.postProcess(functionArgument: processResult.element,
                                              passContext: processResult.passContext)

--- a/Sources/AST/Statement/DoCatchStatement.swift
+++ b/Sources/AST/Statement/DoCatchStatement.swift
@@ -12,11 +12,15 @@ public struct DoCatchStatement: ASTNode {
   public var doBody: [Statement]
   public var catchBody: [Statement]
   public var error: Expression
+  var startToken: Token
+  var endToken: Token
 
-  public init(doBody: [Statement], catchBody: [Statement], error: Expression) {
+  public init(doBody: [Statement], catchBody: [Statement], error: Expression, startToken: Token, endToken: Token) {
     self.doBody = doBody
     self.catchBody = catchBody
     self.error = error
+    self.startToken = startToken
+    self.endToken = endToken
   }
 
   // Does the do-body contain a call on this level of nesting, may be overwritten while visiting the doBody statement
@@ -24,7 +28,8 @@ public struct DoCatchStatement: ASTNode {
 
   // MARK: - ASTNode
   public var sourceLocation: SourceLocation {
-    return SourceLocation.spanning(doBody[0], to: catchBody[catchBody.count-1])
+    // Out of bounds error
+    return SourceLocation.spanning(startToken, to: endToken)
   }
 
   public var description: String {

--- a/Sources/AST/Statement/DoCatchStatement.swift
+++ b/Sources/AST/Statement/DoCatchStatement.swift
@@ -19,6 +19,9 @@ public struct DoCatchStatement: ASTNode {
     self.error = error
   }
 
+  // Does the do-body contain a call on this level of nesting, may be overwritten while visiting the doBody statement
+  public var containsExternalCall = false
+
   // MARK: - ASTNode
   public var sourceLocation: SourceLocation {
     return SourceLocation.spanning(doBody[0], to: catchBody[catchBody.count-1])

--- a/Sources/AST/Statement/DoCatchStatement.swift
+++ b/Sources/AST/Statement/DoCatchStatement.swift
@@ -23,12 +23,11 @@ public struct DoCatchStatement: ASTNode {
     self.endToken = endToken
   }
 
-  // Does the do-body contain a call on this level of nesting, may be overwritten while visiting the doBody statement
+  // Does the do-body contain a call on this level of nesting, may be set while visiting a statement in doBody
   public var containsExternalCall = false
 
   // MARK: - ASTNode
   public var sourceLocation: SourceLocation {
-    // Out of bounds error
     return SourceLocation.spanning(startToken, to: endToken)
   }
 

--- a/Sources/Parser/Parser+Statements.swift
+++ b/Sources/Parser/Parser+Statements.swift
@@ -124,15 +124,16 @@ extension Parser {
 
   func parseDoCatchStatement() throws -> DoCatchStatement {
     // Parse do block
-    try consume(.do, or: .expectedStatement(at: latestSource))
+    let doToken = try consume(.do, or: .expectedStatement(at: latestSource))
     let (doStatements, _) = try parseCodeBlock()
     // Parse catch is Error
     try consume(.catch, or: .expectedStatement(at: latestSource))
     try consume(.is, or: .expectedStatement(at: latestSource))
     let err = try parseErrorType()
 
-    let (catchStatements, _) = try parseCodeBlock()
-    return DoCatchStatement(doBody: doStatements, catchBody: catchStatements, error: err)
+    let (catchStatements, endToken) = try parseCodeBlock()
+    return DoCatchStatement(doBody: doStatements, catchBody: catchStatements, error: err, startToken: doToken,
+                            endToken: endToken)
   }
 
   func parseErrorType() throws -> Expression {

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
@@ -135,7 +135,7 @@ extension SemanticAnalyzer {
     switch externalCall.mode {
     case .normal:
       // Ensure `call` is only used inside do-catch block
-      if passContext.doBlockNestingCount <= 0 {
+      if passContext.doCatchStatementStack.count <= 0 {
         diagnostics.append(.normalExternalCallOutsideDoCatch(externalCall))
       }
     case .returnsGracefullyOptional:
@@ -147,7 +147,7 @@ extension SemanticAnalyzer {
       }
     case .isForced:
       // Ensure 'call!' is never used inside a do-catch block
-      if passContext.doBlockNestingCount > 0 {
+      if passContext.doCatchStatementStack.count > 0 {
         diagnostics.append(.forcedExternalCallInsideDoCatch(externalCall))
       }
     default:

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
@@ -143,7 +143,12 @@ extension SemanticAnalyzer {
       if environment.type(of: externalCall.functionCall.rhs,
                           enclosingType: enclosingType,
                           scopeContext: passContext.scopeContext!) == .basicType(.void) {
-        diagnostics.append(.optionalExternalCallWithoutReturnType(externalCall: externalCall))
+        diagnostics.append(.optionalExternalCallWithoutReturnType(externalCall))
+      }
+    case .isForced:
+      // Ensure 'call!' is never used inside a do-catch block
+      if passContext.doBlockNestingCount > 0 {
+        diagnostics.append(.forcedExternalCallInsideDoCatch(externalCall))
       }
     default:
       break

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
@@ -138,7 +138,11 @@ extension SemanticAnalyzer {
       // Ensure `call` is only used inside the do-body of do-catch statement
       if passContext.doCatchStatementStack.last != nil {
         // Update containsExternallCall value of doCatchStatement
-        passContext.doCatchStatementStack[passContext.doCatchStatementStack.count - 1].containsExternalCall = true
+        var doCatchStatementStack = passContext.doCatchStatementStack
+        doCatchStatementStack[doCatchStatementStack.count - 1].containsExternalCall = true
+        passContext = passContext.withUpdates {
+          $0.doCatchStatementStack = doCatchStatementStack
+        }
       } else {
         diagnostics.append(.normalExternalCallOutsideDoCatch(externalCall))
       }

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
@@ -112,8 +112,6 @@ extension SemanticAnalyzer {
       "gas": false
     ]
     var diagnostics = [Diagnostic]()
-    let environment = passContext.environment!
-    let enclosingType = passContext.enclosingTypeIdentifier!.name
     var passContext = passContext
 
     // ensure only one instance of value and gas hyper-parameters
@@ -147,11 +145,9 @@ extension SemanticAnalyzer {
         diagnostics.append(.normalExternalCallOutsideDoCatch(externalCall))
       }
     case .returnsGracefullyOptional:
-      // Ensure 'call?' is only called with a returning function
-      if environment.type(of: externalCall.functionCall.rhs,
-                          enclosingType: enclosingType,
-                          scopeContext: passContext.scopeContext!) == .basicType(.void) {
-        diagnostics.append(.optionalExternalCallWithoutReturnType(externalCall))
+      // Ensure 'call?' is only used in an 'if let ... = call? ...' construct
+      if !passContext.isIfLetConstruct {
+        diagnostics.append(.optionalExternalCallOutsideIfLet(externalCall))
       }
     case .isForced:
       // Ensure 'call!' is never used inside a do-catch block

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
@@ -26,6 +26,13 @@ extension SemanticAnalyzer {
       } else if lhsType == .selfType, passContext.traitDeclarationContext == nil {
         diagnostics.append(.useOfSelfOutsideTrait(at: binaryExpression.lhs.sourceLocation))
       }
+    case .equal:
+      // Check if `call?` assignment
+      if case .externalCall(let externalCall) = binaryExpression.rhs,
+        externalCall.mode != .returnsGracefullyOptional,
+        passContext.isInsideIfCondition {
+        diagnostics.append(.ifLetConstructWithoutOptionalExternalCall(binaryExpression))
+      }
     default:
       break
     }

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Expressions.swift
@@ -26,12 +26,6 @@ extension SemanticAnalyzer {
       } else if lhsType == .selfType, passContext.traitDeclarationContext == nil {
         diagnostics.append(.useOfSelfOutsideTrait(at: binaryExpression.lhs.sourceLocation))
       }
-    case .equal:
-      // Check if `call?` assignment
-      if case .externalCall(let externalCall) = binaryExpression.rhs,
-        externalCall.mode == .returnsGracefullyOptional {
-        diagnostics.append(.externalCallOptionalAssignmentNotImplemented(binaryExpression))
-      }
     default:
       break
     }

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Statements.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Statements.swift
@@ -48,8 +48,8 @@ extension SemanticAnalyzer {
     return ASTPassResult(element: ifStatement, diagnostics: diagnostics, passContext: passContext)
   }
 
-  public func postProcess(doCatchStatement: DoCatchStatement, passContext: ASTPassContext)
-    -> ASTPassResult<DoCatchStatement> {
+  public func postProcess(doCatchStatement: DoCatchStatement,
+                          passContext: ASTPassContext) -> ASTPassResult<DoCatchStatement> {
       var diagnostics = [Diagnostic]()
 
       if !doCatchStatement.containsExternalCall {

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Statements.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Statements.swift
@@ -47,4 +47,15 @@ extension SemanticAnalyzer {
 
     return ASTPassResult(element: ifStatement, diagnostics: diagnostics, passContext: passContext)
   }
+
+  public func postProcess(doCatchStatement: DoCatchStatement, passContext: ASTPassContext)
+    -> ASTPassResult<DoCatchStatement> {
+      var diagnostics = [Diagnostic]()
+
+      if !doCatchStatement.containsExternalCall {
+        diagnostics.append(.doCatchStatementContainsNoExternalCall(doCatchStatement))
+      }
+
+      return ASTPassResult(element: doCatchStatement, diagnostics: diagnostics, passContext: passContext)
+  }
 }

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -502,9 +502,14 @@ extension Diagnostic {
                       message: "Assignment to the optional result of 'call?' is not yet implemented")
   }
 
-  static func optionalExternalCallWithoutReturnType(externalCall: ExternalCall) -> Diagnostic {
+  static func optionalExternalCallWithoutReturnType(_ externalCall: ExternalCall) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
                       message: "Cannot use 'call?' with external function that has no return type")
+  }
+
+  static func forcedExternalCallInsideDoCatch(_ externalCall: ExternalCall) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
+                      message: "Cannot use `call!` inside do-catch block.")
   }
 
   static func invalidExternalCallHyperParameter(_ identifier: Identifier) -> Diagnostic {

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -511,6 +511,11 @@ extension Diagnostic {
                       message: "Only inside 'if let ... = call?' may 'call?' be used")
   }
 
+  static func ifLetConstructWithoutOptionalExternalCall(_ binaryExpression: BinaryExpression) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: binaryExpression.sourceLocation,
+                      message: "'if let' construct may only be used with 'call?'")
+  }
+
   static func externalCallReturnValueIgnored(_ externalCall: ExternalCall) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
                       message: "Return value of external call cannot be ignored.")

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -502,19 +502,19 @@ extension Diagnostic {
                       message: "Assignment to the optional result of 'call?' is not yet implemented")
   }
 
-  static func optionalExternalCallWithoutReturnType(_ externalCall: ExternalCall) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
-                      message: "Cannot use 'call?' with external function that has no return type")
-  }
-
   static func forcedExternalCallInsideDoCatch(_ externalCall: ExternalCall) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
-                      message: "Cannot use 'call!' inside do-catch block.")
+                      message: "Cannot use 'call!' inside do-catch block")
   }
 
   static func doCatchStatementContainsNoExternalCall(_ doCatchStatement: DoCatchStatement) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: doCatchStatement.sourceLocation,
-                      message: "No 'call' found in do-catch block.")
+                      message: "No 'call' found in do-catch block")
+  }
+
+  static func optionalExternalCallOutsideIfLet(_ externalCall: ExternalCall) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
+                      message: "Only inside 'if let ... = call?' may 'call?' be used")
   }
 
   static func invalidExternalCallHyperParameter(_ identifier: Identifier) -> Diagnostic {

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -496,12 +496,6 @@ extension Diagnostic {
                       message: "Cannot use 'call' outside do-catch block")
   }
 
-  // As there are currently no optional types, we cannot assign to an optional return type.
-  static func externalCallOptionalAssignmentNotImplemented(_ variableDeclarationExpr: BinaryExpression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: variableDeclarationExpr.sourceLocation,
-                      message: "Assignment to the optional result of 'call?' is not yet implemented")
-  }
-
   static func forcedExternalCallInsideDoCatch(_ externalCall: ExternalCall) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
                       message: "Cannot use 'call!' inside do-catch block")

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -517,6 +517,11 @@ extension Diagnostic {
                       message: "Only inside 'if let ... = call?' may 'call?' be used")
   }
 
+  static func externalCallReturnValueIgnored(_ externalCall: ExternalCall) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
+                      message: "Return value of external call cannot be ignored.")
+  }
+
   static func invalidExternalCallHyperParameter(_ identifier: Identifier) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
                       message: "'\(identifier.name)' is not a valid external call hyper-parameter")

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -509,7 +509,12 @@ extension Diagnostic {
 
   static func forcedExternalCallInsideDoCatch(_ externalCall: ExternalCall) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: externalCall.sourceLocation,
-                      message: "Cannot use `call!` inside do-catch block.")
+                      message: "Cannot use 'call!' inside do-catch block.")
+  }
+
+  static func doCatchStatementContainsNoExternalCall(_ doCatchStatement: DoCatchStatement) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: doCatchStatement.sourceLocation,
+                      message: "No 'call' found in do-catch block.")
   }
 
   static func invalidExternalCallHyperParameter(_ identifier: Identifier) -> Diagnostic {

--- a/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
+++ b/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
@@ -13,6 +13,10 @@ Contract :: (any) {
     return 42
   }
 
+  func someFuncWithParam(param: Int) {
+
+  }
+
   public init() {
     do { // expected-error {{No 'call' found in do-catch block}}
       do {
@@ -74,6 +78,23 @@ Contract :: (any) {
     if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
 
     } 
+
+    do {
+      call self.someReturningFunc() // expected-error {{Return value of external call cannot be ignored.}}
+    } catch is Error {
+
+    }
+
+    do {
+      let x: Int = call self.someReturningFunc()
+      self.someFuncWithParam(param: call self.someReturningFunc())
+    } catch is Error {
+
+    }
+
+    call! self.someReturningFunc() // expected-error {{Return value of external call cannot be ignored.}} 
+    self.someFuncWithParam(param: call! self.someReturningFunc())
     
+    let x: Int = call! self.someReturningFunc() 
   }
 }

--- a/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
+++ b/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
@@ -80,6 +80,18 @@ Contract :: (any) {
     } 
 
     do {
+      if let x: Int = call self.someReturningFunc() { // expected-error {{'if let' construct may only be used with 'call?'}}
+
+      }
+    } catch is Error {
+
+    }
+
+    if let y: Int = call! self.someReturningFunc() { // expected-error {{'if let' construct may only be used with 'call?'}}
+
+    }
+
+    do {
       call self.someReturningFunc() // expected-error {{Return value of external call cannot be ignored.}}
     } catch is Error {
 

--- a/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
+++ b/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
@@ -1,0 +1,36 @@
+// RUN: %flintc %s --verify
+
+contract Contract {
+
+}
+
+Contract :: (any) {
+  func someFunc() {
+
+  }
+
+  func someReturningFunc() -> Int {
+    return 42
+  }
+
+  public init() {
+    do {
+      call! self.someFunc() // expected-error {{Cannot use `call!` inside do-catch block.}}     
+    } catch is Error {
+
+    }
+
+    do {
+
+    } catch is Error {
+
+    } // expected-error {{No `call` found in do-catch block.}}
+
+    do {
+      let x: Int = call? self.someReturningFunc()
+      call self.someFunc()
+    } catch is Error {
+
+    }
+  }
+}

--- a/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
+++ b/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
@@ -63,7 +63,7 @@ Contract :: (any) {
     } 
 
     do {
-      if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+      if let x: Int = call? self.someReturningFunc() { 
 
       } else {
 
@@ -75,7 +75,7 @@ Contract :: (any) {
 
     call? self.someReturningFunc() // expected-error {{Only inside 'if let ... = call?' may 'call?' be used}}
 
-    if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+    if let x: Int = call? self.someReturningFunc() { 
 
     } 
 

--- a/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
+++ b/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
@@ -14,7 +14,7 @@ Contract :: (any) {
   }
 
   public init() {
-    do { // expected-error {{No 'call' found in do-catch block.}}
+    do { // expected-error {{No 'call' found in do-catch block}}
       do {
         call self.someFunc()
       } catch is Error {
@@ -26,7 +26,7 @@ Contract :: (any) {
 
     do { 
       call self.someFunc()
-      do { // expected-error {{No 'call' found in do-catch block.}}
+      do { // expected-error {{No 'call' found in do-catch block}}
 
       } catch is Error {
 
@@ -46,23 +46,34 @@ Contract :: (any) {
 
     }
 
-    do { // expected-error {{No 'call' found in do-catch block.}}
-      call! self.someFunc() // expected-error {{Cannot use 'call!' inside do-catch block.}}     
+    do { // expected-error {{No 'call' found in do-catch block}}
+      call! self.someFunc() // expected-error {{Cannot use 'call!' inside do-catch block}}     
     } catch is Error {
 
     } 
 
-    do { // expected-error {{No 'call' found in do-catch block.}}
+    do { // expected-error {{No 'call' found in do-catch block}}
 
     } catch is Error {
 
     } 
 
     do {
-      let x: Int = call? self.someReturningFunc() // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+      if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+
+      } else {
+
+      }
       call self.someFunc()
     } catch is Error {
 
     }
+
+    call? self.someReturningFunc() // expected-error {{Only inside 'if let ... = call?' may 'call?' be used}}
+
+    if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+
+    } 
+    
   }
 }

--- a/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
+++ b/Tests/Integration/SemanticTests/external_call_do_catch_handling.flint
@@ -14,20 +14,52 @@ Contract :: (any) {
   }
 
   public init() {
-    do {
-      call! self.someFunc() // expected-error {{Cannot use `call!` inside do-catch block.}}     
+    do { // expected-error {{No 'call' found in do-catch block.}}
+      do {
+        call self.someFunc()
+      } catch is Error {
+
+      }
+    } catch is Error {
+
+    } 
+
+    do { 
+      call self.someFunc()
+      do { // expected-error {{No 'call' found in do-catch block.}}
+
+      } catch is Error {
+
+      } 
     } catch is Error {
 
     }
 
     do {
+      call self.someFunc()
+      do {
+        call self.someFunc()
+      } catch is Error {
+
+      } 
+    } catch is Error {
+
+    }
+
+    do { // expected-error {{No 'call' found in do-catch block.}}
+      call! self.someFunc() // expected-error {{Cannot use 'call!' inside do-catch block.}}     
+    } catch is Error {
+
+    } 
+
+    do { // expected-error {{No 'call' found in do-catch block.}}
 
     } catch is Error {
 
-    } // expected-error {{No `call` found in do-catch block.}}
+    } 
 
     do {
-      let x: Int = call? self.someReturningFunc()
+      let x: Int = call? self.someReturningFunc() // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
       call self.someFunc()
     } catch is Error {
 

--- a/Tests/Integration/SemanticTests/external_calls.flint
+++ b/Tests/Integration/SemanticTests/external_calls.flint
@@ -94,7 +94,7 @@ Contract :: (any) {
 
     call? self.someFunc() // expected-error {{Only inside 'if let ... = call?' may 'call?' be used}}
 
-    if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+    if let x: Int = call? self.someReturningFunc() { 
 
     }
   }

--- a/Tests/Integration/SemanticTests/external_calls.flint
+++ b/Tests/Integration/SemanticTests/external_calls.flint
@@ -64,14 +64,14 @@ Contract :: (any) {
     // RETURN/TYPE CHECKS
     call self.someFunc() // expected-error {{Cannot use 'call' outside do-catch block}}
 
-    call self.someReturningFunc() // expected-error {{Cannot use 'call' outside do-catch block}}
+    let i1: Int = call self.someReturningFunc() // expected-error {{Cannot use 'call' outside do-catch block}}
 
     do {
         call self.someFunc()
 
-        call self.someReturningFunc()
+        let i2: Int = call self.someReturningFunc()
 
-        let x: Int = call self.someReturningFunc()
+        let i3: Int = call self.someReturningFunc()
 
         let y: Bool = call self.someReturningFunc() // expected-error {{Incompatible assignment between values of type 'Bool' and 'Int'}}
 
@@ -86,7 +86,7 @@ Contract :: (any) {
 
     call! self.someFunc()
 
-    call! self.someReturningFunc()
+    let i4: Int = call! self.someReturningFunc()
 
     let x2: Int = call! self.someReturningFunc()
 

--- a/Tests/Integration/SemanticTests/external_calls.flint
+++ b/Tests/Integration/SemanticTests/external_calls.flint
@@ -78,7 +78,7 @@ Contract :: (any) {
       do {
         call self.someFunc()   
       } catch is Error {
-        call self.someFunc()
+
       }
     } catch is Error {
 

--- a/Tests/Integration/SemanticTests/external_calls.flint
+++ b/Tests/Integration/SemanticTests/external_calls.flint
@@ -78,7 +78,7 @@ Contract :: (any) {
       do {
         call self.someFunc()   
       } catch is Error {
-
+        call self.someFunc()   
       }
     } catch is Error {
 
@@ -92,9 +92,11 @@ Contract :: (any) {
 
     let y2: Bool = call! self.someReturningFunc() // expected-error {{Incompatible assignment between values of type 'Bool' and 'Int'}}
 
-    call? self.someFunc() // expected-error {{Cannot use 'call?' with external function that has no return type}}
+    call? self.someFunc() // expected-error {{Only inside 'if let ... = call?' may 'call?' be used}}
 
-    let x: Int = call? self.someReturningFunc() // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+    if let x: Int = call? self.someReturningFunc() { // expected-error {{Assignment to the optional result of 'call?' is not yet implemented}}
+
+    }
   }
 }
 


### PR DESCRIPTION
Closes #97, and closes #96 in combination with #98.

 - [x] check that `call!` always occurs outside a `do ... catch` block
 - [x] check that there is always a `call` inside a `do ... catch` block
 - [x] check that `call?` is only used in an `if let ...` construct
 - [x] check that an external call return value is never ignored 
 - [x] check that `if let` is used only with `call?`

Replaces #113