### PR TITLE
Fix Swiftlint & Truffle version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - npm install
     - npm install -g truffle
     - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
-    - git clone https://github.com/realm/SwiftLint.git /tmp/swiftlint
+    - git clone -b "0.29.0" https://github.com/realm/SwiftLint.git /tmp/swiftlint
     - (cd /tmp/swiftlint; swiftenv install; swift build -c release --static-swift-stdlib)
     - export PATH="/tmp/swiftlint/.build/x86_64-unknown-linux/release:$PATH"
     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ matrix:
     before_install:
     - sudo add-apt-repository -y ppa:ethereum/ethereum
     - sudo apt-get update
-    - sudo apt-get -y install solc
     - npm install
-    - npm install -g truffle
+    - npm install -g truffle@4.1.14
     - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
     - git clone -b "0.29.0" https://github.com/realm/SwiftLint.git /tmp/swiftlint
     - (cd /tmp/swiftlint; swiftenv install; swift build -c release --static-swift-stdlib)

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update
 RUN apt-get -y install solc nodejs
 RUN npm install
 RUN npm install -g truffle
-RUN git clone https://github.com/realm/SwiftLint.git /tmp/swiftlint
+RUN git clone -b "0.29.0" https://github.com/realm/SwiftLint.git /tmp/swiftlint
 RUN (cd /tmp/swiftlint; swift build -c release --static-swift-stdlib)
 ENV PATH="/tmp/swiftlint/.build/x86_64-unknown-linux/release:${PATH}"
 


### PR DESCRIPTION
Fix the swiftlint version to 0.29.0, the last known to work locally on my version of macOS. This way we protect ourselves from new rules being introduced to swiftlint that break our CI.
Fixed truffle version to 4.1.14 in travis.